### PR TITLE
Fixed incorrect type for unique ID lookup

### DIFF
--- a/src/Processor/Recurrent/Update.php
+++ b/src/Processor/Recurrent/Update.php
@@ -265,12 +265,12 @@ abstract class Update implements IDryRunProcessor {
 	}
 
 	/**
-	 * @param int $_identifier
+	 * @param string $_identifier
 	 *
 	 * @throws SetReaderException
 	 * @return IIndexedEntity|null
 	 */
-	protected function readSystemEntityByIdentifier( int $_identifier ): ?IIndexedEntity {
+	protected function readSystemEntityByIdentifier( string $_identifier ): ?IIndexedEntity {
 		return $this->_systemService->readByUniqueIdentifier( $_identifier );
 	}
 


### PR DESCRIPTION
Fix an incorrect type parameter which did not match the interface, previously worked due to type coercion.