### PR TITLE
WordPress Term Retrieval Error Checks

### DIFF
--- a/src/Repositories/WordPress/PostTerms.php
+++ b/src/Repositories/WordPress/PostTerms.php
@@ -28,9 +28,10 @@ class PostTerms implements IIndexedEntityGroupWriter {
 	 * {@inheritDoc}
 	 */
 	public function read( int $_identifier, string $_group_key ): EntityIterator {
-		$terms = wp_get_object_terms( $_identifier, $_group_key );
+		$terms   = wp_get_object_terms( $_identifier, $_group_key );
+		$isValid = false !== $terms && ! is_a( $terms, WP_Error::class );
 
-		return new EntityIterator( false !== $terms ? $terms : [], WP_Term::class );
+		return new EntityIterator( $isValid ? $terms : [], WP_Term::class );
 	}
 
 	/**

--- a/src/Repositories/WordPress/Taxonomy.php
+++ b/src/Repositories/WordPress/Taxonomy.php
@@ -73,8 +73,9 @@ class Taxonomy implements IGroupSetWriter {
 		);
 		$taxonomy_query->appendMaybe( $_filter, is_array( $_filter ) );
 		$taxonomy_terms = get_terms( $taxonomy_query->toArray() );
+		$isValid        = false !== $taxonomy_terms && ! is_a( $taxonomy_terms, WP_Error::class );
 
-		return new EntityIterator( false !== $taxonomy_terms ? $taxonomy_terms : [], $entity_type );
+		return new EntityIterator( $isValid ? $taxonomy_terms : [], $entity_type );
 	}
 
 	/**


### PR DESCRIPTION
## Description
> As a developer, I need to ensure fatal errors don't occur when retrieving terms

- Add WP_Error checks when searching for taxonomy terms

## Steps to Validate
1. Pull the branch into an existing project which uses Taxonomy Term and Post Term retrieval
2. Run the import/export routine for invalid taxonomies
3. Verify Fatal Errors are no longer thrown
