### PR TITLE
WordPress Media Reporting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,22 +12,19 @@ PHP library to provide common model and service patterns for building other appl
 
 ## Definitions
 
-* **Entity** - Any structured model, class, interface, etc representing data flowing through the system. 
-  The model contains sets of data fields with free-form and indexed content. For instance, a Post Type or 
-  Node which represents a Location with a free-form Address and an indexed Region or State.
-* **Entity Iterator** - PHP Iterator which takes a Class, Interface or Scalar type and validates each 
-  member entity is of the requested type
-* **Indexed Entity** - Any entity which uses a numerical index, for instance, a Post Type in WordPress 
-  uses a Post ID, its index.
-* **Indexed Group Entity** - Perhaps written in a grammatically incorrect way, this is a Group associated 
-  with an indexed entity, for instance a City/Region taxonomy associated with a Location
-* **Reader** - Data repository which only allows reading
-* **Repository** - Generic name for a place to store data, could be a CSV file, HTTP/S Endpoint, Database, etc.
-* **Set** - A grouping of similar data, generally expected to be of the same entity in this system, 
-  enforced using Entity Iterators
-* **Stream** - Flow of data between repositories, this system implements streams to read from source 
-  repositories and write to target repositories 
-* **Writer** - Data repository which allows reading/writing
+| Concept                  | Definition                                                                                                                                                                                                                                                                                           |
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Entity**               | Any structured model, class, interface, etc representing data flowing through the system. The model contains one or more data fields with free-form and indexed content. For instance, a Post Type or Node which represents a Location with a free-form Address and an indexed City/Region or State. |
+| **Entity Iterator**      | PHP Iterator which takes a Class, Interface, or Scalar type and validates each member **Entity** is of the requested type                                                                                                                                                                            |
+| **Indexed Entity**       | Any entity for a set using a numerical index, for instance, a Post Type in WordPress the numeric ID field.                                                                                                                                                                                           |
+| **Indexed Group Entity** | A **set** of **Entities** associated with another **Indexed Entity** by a common index, for instance a City/Region taxonomy associated with a Location                                                                                                                                               |
+| **Processor**            | Coordinate one or more **Services** or **Repositories** in a data process, for instance read a **Set** or **Entities** for a CSV to determine if there are **Entities** to create or update in the target system.                                                                                    |
+| **Reader**               | Data repository in read-only mode.                                                                                                                                                                                                                                                                   |
+| **Repository**           | Generic place to store data, could be a CSV file, HTTP/S Endpoint, Database, etc.                                                                                                                                                                                                                    |
+| **Set**                  | A group of similar data, generally expected to be of the same **Entity** in this system, wrapped in an **Entity Iterator**                                                                                                                                                                           |
+| **Service**              | Coordinate data management between one or more **Repositories** for a single **Entity** type, for instance coordinate data flow between the Post, Meta, and Taxonomy for a WordPress post type; or turn a CSV into a Post Type **Entity** for processing                                             |
+| **Stream**               | Flow of data between **Repositories**, this system reads data from source **Repositories** and writes it to target **Repositories**                                                                                                                                                                  |
+| **Writer**               | Data repository which allows reading/writing                                                                                                                                                                                                                                                         |
 
 
 ## Structure
@@ -42,6 +39,13 @@ Group of commonly used CLI Commands available to register and use on WordPress, 
 
 For WordPress, all commands are for WPCLI, and can be registered from this library by calling 
 `Kanopi\Components\Commands\Registration::WPCLICommands()`.
+
+| CLI Commands                          | Purpose                                                                |
+|:--------------------------------------|:-----------------------------------------------------------------------|
+| `wp kanopi-report-flex-content audit` | Report a WordPress sites ACF flexible content areas                    |
+| `wp kanopi-report-post-type audit`    | Report a WordPress sites content in post types                         |
+| `wp kanopi-report-post-type media`    | Report all referenced site media; show if each is in the Media Library |
+
 
 ### Logger
 
@@ -96,7 +100,7 @@ Interfaces to coordinate data processing from external sources into an local sys
 
 Components which consolidate and simplify the transformation of standard/scalar data types into 
 coordinated structures of data for more readable and concise functionality. For instance,
-string utilities which sanitize or convert delimiters.
+string utilities which sanitize or convert delimiters and array utilities for fluent, chained manipulation.
 
 ## Code Quality 
 

--- a/src/Commands/WordPress/Report/PostType.php
+++ b/src/Commands/WordPress/Report/PostType.php
@@ -300,6 +300,316 @@ class PostType extends WP_CLI_Command {
 	}
 
 	/**
+	 * Generate an audit report of all Site media, segmented to show those in and out of the Media Library
+	 *
+	 * ## OPTIONS
+	 *
+	 *  <directory>
+	 *   : Directory to write the audit exports
+	 *
+	 * <filePrefix>
+	 *   : Prefix for each of the generated CSV files
+	 *
+	 * [--post-statuses[=<postStatusList>]]
+	 *    : Comma-delimited list of post status slugs to lookup and report
+	 *   ---
+	 *   default: all
+	 *   ---
+	 *
+	 *  [--post-types[=<postTypeList>]]
+	 *   : Comma-delimited list of post type slugs to lookup and report
+	 *  ---
+	 *  default: all
+	 *  ---
+	 *
+	 * [--private-post-types]
+	 *  : Set to show private post types, otherwise only public are shown
+	 * ---
+	 * default: false
+	 * ---
+	 *
+	 * [--replace-site-url[=<replacementSiteUrl>]]
+	 *   : Rewrite the local domain and protocol in URLs, i.e. turn http://test.docksal.site into https://www.test.com
+	 *  ---
+	 *  default: ''
+	 *  ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *        wp kanopi-report-post-type media ./ audit-
+	 *
+	 * @subcommand media
+	 */
+	public function media( $_cliArguments, $_associative_arguments ): void {
+		try {
+			$directory           = $_cliArguments[0] ?? '';
+			$filePrefix          = $_cliArguments[1] ?? '';
+			$replacementSiteUrl  = $_associative_arguments['replace-site-url'] ?? '';
+			$statusSlugs         = $_associative_arguments['post-statuses'] ?? '';
+			$typeSlugs           = $_associative_arguments['post-types'] ?? '';
+			$usePrivatePostTypes = isset( $_associative_arguments['private-post-types'] );
+
+			if ( empty( $directory ) ) {
+				throw new InvalidArgumentException( 'Specify a directory for the audit files' );
+			}
+
+			if ( empty( $filePrefix ) ) {
+				throw new InvalidArgumentException( 'Specify a prefix for each of the audit files' );
+			}
+
+			$defaultPathPattern = '/(?:href|src)=["\']([^"\']+\.(mp3|mp4|avi|mov|jpg|jpeg|png|gif|svg|webp|apng|avif|pdf))["\']/i';
+			$defaultSizePattern = '/(https?:\/\/[^\/]+\/(?:[^\/]+\/)*[^\/]+)(?:-(\d+x\d+))\.(\w+)/i';
+
+			/**
+			 * Filter the regex pattern to parse all media paths from each posts content
+			 *  - Default searches for all 'href' and 'src' URLs in the provided content
+			 *  - Regex is a preg_match_all and uses match array 1
+			 *
+			 * @param string $defaultPathPattern Default Path regex pattern
+			 */
+			$mediaPathPattern = apply_filters( 'kanopi_report_media_path_regex_pattern', $defaultPathPattern );
+
+			/**
+			 * Filter the regex pattern to parse out resized image paths, extract the size if present
+			 *  - Processing to read and determine if a Media URL is the Default URL or contains a sized variant
+			 *  - Constructs the Default URL from concatenating matches 1 and 3
+			 *  - The size variant is expected in match 2
+			 *  - For no match, the URL is considered the Default, i.e. it is the full image or a document with no size
+			 *
+			 * @param string $defaultSizePattern Default URL Size regex pattern
+			 */
+			$mediaUrlSizePattern = apply_filters( 'kanopi_report_media_url_size_regex_pattern', $defaultSizePattern );
+
+			// Execution tracking
+			$start = new DateTime();
+
+			// Image audit output array
+			$audit = Arrays::fresh();
+
+			// Image size tracking array
+			$sizes = Arrays::from( [ 'Default' => 0 ] );
+
+			// Process statistics tracking
+			$statistics = new IndexedProcessStatistics();
+
+			// Find all available post types for a name lookup
+			$postTypes = $this->readPostTypes( $typeSlugs, $usePrivatePostTypes );
+
+			// Set of published/private posts in requested post types, including any assigned template file
+			$this->postWriter->changeFilters(
+				new WordPressEntityFilters(
+					[ '_wp_page_template' ],
+					! empty( $statusSlugs ) ? explode( ',', $statusSlugs ) : [ 'publish', 'private' ],
+					[],
+					array_keys( $postTypes->toArray() )
+				)
+			);
+			$content = $this->postWriter->read();
+			$statistics->incomingTotal( $content->count() );
+
+			// Current site URL
+			$siteUrl = home_url();
+			if ( str_ends_with( $siteUrl, '/' ) ) {
+				$siteUrl = rtrim( $siteUrl, '/' );
+			}
+			$baseMediaUrl = wp_upload_dir( null, true, true )['baseurl'] ?? $siteUrl . '/wp-content/uploads';
+
+			$mediaUrls = Arrays::fresh();
+
+			/**
+			 * Use the Content Index to iterate over and generate the final audit
+			 *
+			 * @var GenericWordPressEntity $contentPost Current WordPress post entity
+			 */
+			foreach ( $content as $postIdentifier ) {
+				$contentPost   = $this->postWriter->readByIndexIdentifier( $postIdentifier );
+				$postUrl       = get_permalink( $contentPost->indexIdentifier() );
+				$postTypeName  = $postTypes->readIndex( $contentPost->systemEntityName() )
+					?? $contentPost->systemEntityName();
+				$template      = $contentPost->metaFields->readIndex( '_wp_page_template' );
+				$postTimestamp = strtotime( $contentPost->datePublished() );
+
+				/**
+				 * Standard WordPress content filters to mimic the front-end post content template process
+				 */
+				$postContent = apply_filters(
+					'the_content',
+					get_the_content(
+						null,
+						false,
+						$contentPost->internalSystemEntity() ?? $contentPost->indexIdentifier()
+					)
+				);
+
+				/**
+				 * Filters the content for a given post, allows additional processing for content stored
+				 * outside the standard provided $postContent, for instance in ACF flex content areas.
+				 *
+				 * Separate from 'the_content' to avoid conflicts with normal site operation.
+				 *
+				 * @param string                 $postContent Current post content with 'the_content' filters applied
+				 * @param GenericWordPressEntity $contentPost WordPress post entity
+				 * @param string                 $template    Template meta '_wp_page_template' of the current post
+				 */
+				$renderContent = apply_filters(
+					'kanopi_report_media_path_rendered_content',
+					$postContent,
+					$contentPost,
+					$template
+				);
+
+				// Process the Post content to find all referenced Media items
+				preg_match_all( $mediaPathPattern, $renderContent, $matches );
+
+				$mediaPaths     = Arrays::from( $matches[1] ?? [] );
+				$siteMedia      = $mediaPaths->filter(
+					function ( string $_item ) use ( $siteUrl ): bool {
+						return str_starts_with( $_item, $siteUrl );
+					}
+				)->filterUnique();
+				$nonUploadMedia = Arrays::fresh();
+
+				/**
+				 * @var string $media Media URL to process
+				 */
+				foreach ( $siteMedia as $media ) {
+					// Track if the file is inside or outside the Media Library
+					$inMediaLibrary = str_starts_with( $media, $baseMediaUrl );
+					$nonUploadMedia->addMaybe( $media, ! $inMediaLibrary );
+
+					// Find the image size and base file
+					$matchCount = preg_match( $mediaUrlSizePattern, $media, $mediaUrlSizes );
+					$hasSize    = 0 < $matchCount;
+					$fileUrl    = $hasSize ? $mediaUrlSizes[1] . '.' . $mediaUrlSizes[3] : $media;
+					$fileSize   = $hasSize ? $mediaUrlSizes[2] : 'Default';
+
+					// Track the amount of images of a certain size
+					$sizeCount = ( $sizes->readIndex( $fileSize ) ?? 0 ) + 1;
+					$sizes->writeIndex( $fileSize, $sizeCount );
+
+					/**
+					 * Create/Update the Audit Media Tracking item
+					 *
+					 * @var Arrays $currentMediaItem
+					 */
+					$currentMediaItem = $mediaUrls->readIndex( $fileUrl ) ??
+						Arrays::from(
+							[
+								'Type'      => $inMediaLibrary ? 'Library' : 'Legacy',
+								'URL'       => $fileUrl,
+								'Last Used' => '',
+								'Default'   => 0,
+							]
+						);
+					$currentMediaItem->writeIndex( $fileSize, ( $currentMediaItem->readIndex( $fileSize ) ?? 0 ) + 1 );
+					$currentMediaTimestamp = strtotime( $currentMediaItem->readIndex( 'Last Used' ) );
+					if ( $currentMediaTimestamp < $postTimestamp ) {
+						$currentMediaItem->writeIndex( 'Last Used', $contentPost->datePublished() );
+					}
+					$mediaUrls->writeIndex( $fileUrl, $currentMediaItem );
+				}
+
+				$auditEntry = Arrays::from(
+					[
+						'ID'            => $contentPost->indexIdentifier(),
+						'Title'         => $contentPost->title(),
+						'Type'          => $postTypeName,
+						'Public'        => 'publish' === $contentPost->status() ? 'Yes' : 'No',
+						'Published'     => $contentPost->datePublished(),
+						'Modified'      => $contentPost->dateLastModified(),
+						'Template'      => $template,
+						'Site URL'      => ! empty( $replacementSiteUrl )
+							? str_replace( $siteUrl, $replacementSiteUrl, $postUrl )
+							: $postUrl,
+						'Total Images'  => $siteMedia->count(),
+						'Legacy Images' => $nonUploadMedia->count(),
+					]
+				);
+
+				$audit->add( $auditEntry->toArray() );
+			}
+
+			// Post Type report columns (without taxonomies, added below)
+			$reportColumns = Arrays::from(
+				[
+					'ID',
+					'Title',
+					'Type',
+					'Public',
+					'Published',
+					'Modified',
+					'Template',
+					'Site URL',
+					'Total Images',
+					'Legacy Images',
+				]
+			);
+
+			// Create CSV Report of all Posts and their Media counts
+			$this->csvService->writeFile(
+				$reportColumns->toArray(),
+				$audit->readSubArrays(),
+				$directory . $filePrefix . 'content-media-report.csv'
+			);
+
+			// Sort the list of used images sizes, ensuring Default is first
+			$currentSizes = Arrays::fresh();
+			foreach ( array_keys( $sizes->toArray() ) as $size ) {
+				if ( 'Default' === $size ) {
+					continue;
+				}
+				$currentSizes->add( $size );
+			}
+			$currentSizes->filterUnique();
+
+			// Rebuild the Media URL listing to zero out all sizes
+			$auditUrls = Arrays::fresh();
+			foreach ( $mediaUrls as $mUrl ) {
+				$current = Arrays::fresh()
+					->writeIndex( 'Type', $mUrl->readIndex( 'Type' ) )
+					->writeIndex( 'URL', $mUrl->readIndex( 'URL' ) )
+					->writeIndex( 'Last Used', $mUrl->readIndex( 'Last Used' ) )
+					->writeIndex( 'Default', $mUrl->readIndex( 'Default' ) );
+
+				foreach ( $currentSizes as $size ) {
+					$current->writeIndex( $size, $mUrl->readIndex( $size ) ?? 0 );
+				}
+				$auditUrls->add( $current );
+			}
+
+			// Create CSV Report of all Media URLs with counts of usage by size
+			$this->csvService->writeFile(
+				Arrays::from(
+					[
+						'Type',
+						'URL',
+						'Last Used',
+						'Default',
+					]
+				)->append( $currentSizes->toArray() )->toArray(),
+				$auditUrls->readSubArrays(),
+				$directory . $filePrefix . 'content-media-urls.csv'
+			);
+
+			$this->logger->table(
+				[ 'Total', 'Updated', 'Skipped', 'Processed', 'Time Elapsed (h:m:s)' ],
+				[
+					[
+						'Total'                => $statistics->incomingTotalAmount(),
+						'Updated'              => $statistics->updatedAmount(),
+						'Skipped'              => $statistics->skippedAmount(),
+						'Processed'            => $statistics->processedTotalAmount(),
+						'Time Elapsed (h:m:s)' => $start->diff( new DateTime() )->format( '%H:%i:%s' ),
+					],
+				]
+			);
+		}
+		catch ( Exception $exception ) {
+			$this->logger->error( 'Error while running the content audit: ' . $exception->getMessage() );
+		}
+	}
+
+	/**
 	 * Read an associative array of "post type slugs" to "post type name/label"
 	 *  - When provided, limits post types to those requested, otherwise returns all
 	 *

--- a/src/Commands/WordPress/Report/PostType.php
+++ b/src/Commands/WordPress/Report/PostType.php
@@ -475,6 +475,7 @@ class PostType extends WP_CLI_Command {
 				foreach ( $siteMedia as $media ) {
 					// Track if the file is inside or outside the Media Library
 					$inMediaLibrary = str_starts_with( $media, $baseMediaUrl );
+
 					$nonUploadMedia->addMaybe( $media, ! $inMediaLibrary );
 
 					// Find the image size and base file
@@ -482,6 +483,11 @@ class PostType extends WP_CLI_Command {
 					$hasSize    = 0 < $matchCount;
 					$fileUrl    = $hasSize ? $mediaUrlSizes[1] . '.' . $mediaUrlSizes[3] : $media;
 					$fileSize   = $hasSize ? $mediaUrlSizes[2] : 'Default';
+
+					// Check for replacement URL base
+					$fileUrl = ! empty( $replacementSiteUrl )
+						? str_replace( $siteUrl, $replacementSiteUrl, $fileUrl )
+						: $fileUrl;
 
 					// Track the amount of images of a certain size
 					$sizeCount = ( $sizes->readIndex( $fileSize ) ?? 0 ) + 1;

--- a/src/Model/Data/WordPress/PostTypeEntity.php
+++ b/src/Model/Data/WordPress/PostTypeEntity.php
@@ -102,6 +102,15 @@ trait PostTypeEntity {
 	}
 
 	/**
+	 * Direct read access for the internal system entity (WP_Post)
+	 *
+	 * @return WP_Post|null
+	 */
+	public function internalSystemEntity(): ?WP_Post {
+		return $this->wpPost;
+	}
+
+	/**
 	 * @see IIndexedEntity::systemEntityName()
 	 */
 	public function systemEntityName(): string {


### PR DESCRIPTION
## Description
> As a site auditor, I need to catalog the local/site generated Media used on a WordPress site and determine whether it is all in the Media library.

Add a WP CLI command to report all Media (images, documents, etc) used within Post content. 

## Acceptance Criteria
* Reports are generated of Media Usage per Post and Media Usage Count per Size
* Reports can be limited/segmented to individual post types and/or statuses
* Reports can automate replacing any local site URL prefix with another site URL prefix 

## Definition of Done
* Media reports are available and can be generated by default with the component installed and registered

## Steps to Validate
* Use Composer to require the branch as a Dev dependency on a WordPress project
* If not already present in the project, after the Composer auto-loader is run, register the commands with `Registration::WPCLICommands();`
* Run the WP CLI command: `wp kanopi-report-post-type media ./ audit-` which will generate two CSV's, one with the list of posts and media counts, then second with each Media URL and usage per size. If the data set is very large, you can limit to an individual post type with the argument `--post-types=post` 
* For comparison, rerun the command with the argument `--replace-site-url=https://test.org` and confirm all of the report URLs replaced the local domain with the requested domain.
* If time allows, add/use a test template in WordPress for one or more posts with media. Add a filter for `kanopi_report_media_path_rendered_content` (documented in this command comments) to change the content of each templated post. You could for instance, add a fake Media item to each post, which should be counted and show in your reports.

## Assumptions
* You have a WordPress project using Composer
* The Composer auto-loader is added and running in the project
