### PR TITLE
Existing Feature Image IDs 

### DIFF
--- a/src/Processor/WordPress/FeaturedImageProcessor.php
+++ b/src/Processor/WordPress/FeaturedImageProcessor.php
@@ -50,7 +50,7 @@ abstract class FeaturedImageProcessor extends BatchedCursorUpdate {
 			$currentImage   = $this->attachmentService()->readByUniqueIdentifier( "{$filename}(-scaled)?\.{$extension}" );
 			$currentImageId = $currentImage?->indexIdentifier() ?? 0;
 			$_entity->updateFeaturedImageIdentifier(
-				1 > $currentImageId
+				0 < $currentImageId
 					? $this->imageService()->import( $image )
 					: 0
 			);

--- a/src/Processor/WordPress/FeaturedImageProcessor.php
+++ b/src/Processor/WordPress/FeaturedImageProcessor.php
@@ -45,15 +45,12 @@ abstract class FeaturedImageProcessor extends BatchedCursorUpdate {
 
 		// WordPress will scale large images, to accommodate this, use a regular expression to check
 		try {
-			$filename       = pathinfo( $image->fileName, PATHINFO_FILENAME );
-			$extension      = pathinfo( $image->fileName, PATHINFO_EXTENSION );
-			$currentImage   = $this->attachmentService()->readByUniqueIdentifier( "{$filename}(-scaled)?\.{$extension}" );
-			$currentImageId = $currentImage?->indexIdentifier() ?? 0;
-			$_entity->updateFeaturedImageIdentifier(
-				0 < $currentImageId
-					? $this->imageService()->import( $image )
-					: 0
-			);
+			$filename        = pathinfo( $image->fileName, PATHINFO_FILENAME );
+			$extension       = pathinfo( $image->fileName, PATHINFO_EXTENSION );
+			$existingImage   = $this->attachmentService()->readByUniqueIdentifier( "{$filename}(-scaled)?\.{$extension}" );
+			$existingImageId = $existingImage?->indexIdentifier() ?? 0;
+			$nextImageId     = 0 < $existingImageId ? $existingImage : $this->imageService()->import( $image );
+			$_entity->updateFeaturedImageIdentifier( $nextImageId );
 		} catch ( SetReaderException ) {
 			$_entity->updateFeaturedImageIdentifier( $_existingId );
 		}


### PR DESCRIPTION
## Description

Feature Image IDs were being removed when an image already existed in the Media Library for WP Featured Image processing. Need to ensure the update attaches the current image, not just when a new image is imported (current behavior).

## Fix Details

Changed some variable names to more clearly show if an existing attachment/image is find, use its ID, otherwise import the new image and use that id.