### PR TITLE
Node Attribute Adjustments

### DIFF
--- a/src/Blocks/Model/FlowElementTransform.php
+++ b/src/Blocks/Model/FlowElementTransform.php
@@ -97,9 +97,7 @@ trait FlowElementTransform {
 	 */
 	public function verifyClassAttribute( Crawler $_element, array $_expectedClasses ): bool {
 		// Manually split and match instead of HtmlPageCrawler hasClass(), which can only handle one class at a time
-		$attribute = $_element->matches( '*' ) && method_exists( $_element, 'getAttribute' )
-			? $_element->getAttribute( 'class' )
-			: null;
+		$attribute = $_element->matches( '*' ) ? $_element->attr( 'class' ) : null;
 		$classes   = preg_split( '/\s+/', $attribute ?? '' );
 		$checkSet  = false !== $classes ? Arrays::from( $classes ) : Arrays::fresh();
 

--- a/src/Blocks/Model/StandardBlock.php
+++ b/src/Blocks/Model/StandardBlock.php
@@ -89,7 +89,13 @@ trait StandardBlock {
 			$classes->addMaybe( $replacement, $nodeHasOriginal );
 		}
 
-		return $classes->join( ' ' );
+		return trim(
+			$classes->filterUnique()->filter(
+				function ( $_item ) {
+					return ! empty( $_item );
+				}
+			)->join( ' ' )
+		);
 	}
 
 	/**

--- a/src/Blocks/Model/StandardBlock.php
+++ b/src/Blocks/Model/StandardBlock.php
@@ -69,6 +69,14 @@ trait StandardBlock {
 		Arrays $_domAttributes
 	): void {}
 
+	/**
+	 * Flag whether to keep the original set of Node classes when mapping
+	 *  - Override as false in a consuming class to remove the original class listing
+	 */
+	protected function keepOriginalMappedClasses(): bool {
+		return true;
+	}
+
 
 	/**
 	 * Check the nodes class list and replace select classes
@@ -81,7 +89,7 @@ trait StandardBlock {
 		$classes     = Arrays::fresh();
 		$nodeClasses = $_node->attr( 'class' ) ?? '';
 
-		$classes->addMaybe( $nodeClasses, ! empty( $nodeClasses ) );
+		$classes->addMaybe( $nodeClasses, $this->keepOriginalMappedClasses() && ! empty( $nodeClasses ) );
 
 		foreach ( $this->classMapping() as $original => $replacement ) {
 			$nodeHasOriginal = $this->verifyClassAttribute( $_node, [ $original ] );


### PR DESCRIPTION
## Description

Adjust the verification for Class Attributes, now uses the correct attribute function to verify the element class attribute. Additionally adds an option to the StandardBlock trait to toggle whether the transform keeps all original, unmapped classes on the element.

## Steps to Validate

- Pull the branch
- Run `make` and verify all sniffs and tests still pass